### PR TITLE
remove s3 bucket used for data dir

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,23 +18,9 @@ mkdir -p "${CACHE_DIR}"
 
 cd "${CACHE_DIR}"
 
-export_env_dir() {
-  ALLOWLIST_REGEX=${2:-'LIBPOSTAL_S3_BUCKET'}
-  DENYLIST_REGEX=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
-  if [ -d "${ENV_DIR}" ]; then
-    for e in $(ls ${ENV_DIR}); do
-      echo "$e" | grep -E "${ALLOWLIST_REGEX}" | grep -qvE "${DENYLIST_REGEX}" &&
-      export "$e=$(cat ${ENV_DIR}/$e)"
-      :
-    done
-  fi
-}
-
 indent() {
   sed -u 's/^/       /'
 }
-
-export_env_dir
 
 echo "-----> Downloading libpostal"
 
@@ -53,11 +39,6 @@ rm -rf "${CACHE_DIR}"
 mkdir -p "${BUILD_DIR}/libpostal/data/compressed_data"
 
 mv /app/libpostal/* "${BUILD_DIR}/libpostal"
-
-echo "Retrieving libpostal compressed data files and storing them internally" | indent
-
-# Only retrieves a portion of Libpostal's data, the rest is loaded post slug compilation.
-curl -L --silent "${LIBPOSTAL_S3_BUCKET}/libpostal.tar.gz" --output "${BUILD_DIR}/libpostal/data/compressed_data/libpostal.tar.gz"
 
 echo "Building libpostal symbolic links" | indent
 


### PR DESCRIPTION
We don't have an S3 bucket to use for seeding the data directory so
removing this for now. If we determine that we need it for performance
reasons, we can add it back.