### PR TITLE
run ldconfig on linux per the docs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,7 @@ LDFLAGS="-L${BUILD_DIR}/libpostal/lib" CFLAGS="-I${BUILD_DIR}/libpostal/include"
 
 make
 make install
+ldconfig
 
 # remove unused directories
 rm -rf "${CACHE_DIR}"


### PR DESCRIPTION
The `ruby_postal` docs suggest running `ldconfig` on linux. Seems like it could be related to our error: https://man7.org/linux/man-pages/man8/ldconfig.8.html